### PR TITLE
Fix Unlimited Health

### DIFF
--- a/buffer.lua
+++ b/buffer.lua
@@ -218,9 +218,10 @@ data[1] = {
                         local playerbase = playerManager:call("findMasterPlayer")
                         local playerData = playerbase:call("get_PlayerData")
                         local max = playerData:get_field("_vitalMax")
-
+						local maxFloat = max + .0
+                        
                         playerData:set_field("_r_Vital", max)
-                        playerData:call("set__vital", max)
+						playerData:call("set__vital", maxFloat)
                     end
                 end,
                 post = nothing()


### PR DESCRIPTION
set__vital function needs Single, instead of Int32 that provided by getting field _vitalMax.
Although lua seems all numbers as "number"
This causes problem in the game, so adding ".0" to the set__vital fixes the problem